### PR TITLE
Correct wrong update that remove convert_to_slash

### DIFF
--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -24,8 +24,8 @@
 	    "command": "convert_to_separate_words"
 	},
 	{
-	    "caption": "Convert Case: Toggle Case",
-	    "command": "toggle_snake_camel_pascal"
+	    "caption": "Convert Case: separate/with/slash",
+	    "command": "convert_to_slash"
 	},
 	{
 	    "caption": "Convert Case: Toggle Case",


### PR DESCRIPTION
"Convert Case: separate/with/slash" was removed and "Convert Case: Toggle Case" added two times.
