### PR TITLE
Fixed toggle_snake_camel_pascal not handling single-word lowercase variables

### DIFF
--- a/case_conversion.py
+++ b/case_conversion.py
@@ -58,7 +58,7 @@ def toggle_case(text, detectAcronyms, acronyms):
         return to_snake_case(text, detectAcronyms, acronyms)
     elif case == 'lower' and sep == '_':
         return to_camel_case(text, detectAcronyms, acronyms)
-    elif case == 'camel' and not sep:
+    elif (case == 'camel' or case == 'lower') and not sep:
         return to_pascal_case(text, detectAcronyms, acronyms)
     else:
         return text


### PR DESCRIPTION
I tried to toggle a variable named `index` to PascalCase, and found that it did nothing! This is because the variable is neither snake_case nor camelCase, but simply lower case with no separator. This fix treats lower-case-no-separator as camelCase so that it converts to PascalCase, which is more convenient than doing nothing at all.