### PR TITLE
added backslash `\` as separator

### DIFF
--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -5,5 +5,7 @@
   { "keys": ["ctrl+alt+c", "ctrl+alt+d"], "command": "convert_to_dot"},
   { "keys": ["ctrl+alt+c", "ctrl+alt+h"], "command": "convert_to_dash"},
   { "keys": ["ctrl+alt+c", "ctrl+alt+w"], "command": "convert_to_separate_words"},
-  { "keys": ["ctrl+alt+c", "ctrl+alt+/"], "command": "convert_to_slash"}
+  { "keys": ["ctrl+alt+c", "ctrl+alt+/"], "command": "convert_to_slash"},
+  { "keys": ["ctrl+alt+c", "ctrl+alt+b"], "command": "convert_to_back_slash"},
+  { "keys": ["ctrl+shift+-"], "command": "toggle_snake_camel_pascal"}
 ]

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -6,5 +6,6 @@
   { "keys": ["ctrl+alt+c", "ctrl+alt+h"], "command": "convert_to_dash"},
   { "keys": ["ctrl+alt+c", "ctrl+alt+w"], "command": "convert_to_separate_words"},
   { "keys": ["ctrl+alt+c", "ctrl+alt+/"], "command": "convert_to_slash"},
+  { "keys": ["ctrl+alt+c", "ctrl+alt+b"], "command": "convert_to_back_slash"},
   { "keys": ["ctrl+shift+-"], "command": "toggle_snake_camel_pascal"}
 ]

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -6,5 +6,6 @@
   { "keys": ["ctrl+alt+c", "ctrl+alt+h"], "command": "convert_to_dash"},
   { "keys": ["ctrl+alt+c", "ctrl+alt+w"], "command": "convert_to_separate_words"},
   { "keys": ["ctrl+alt+c", "ctrl+alt+/"], "command": "convert_to_slash"},
+  { "keys": ["ctrl+alt+c", "ctrl+alt+b"], "command": "convert_to_back_slash"},
   { "keys": ["ctrl+shift+-"], "command": "toggle_snake_camel_pascal"}
 ]

--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -28,6 +28,10 @@
 	    "command": "convert_to_slash"
 	},
 	{
+	    "caption": "Convert Case: separate\\with\\backslash",
+	    "command": "convert_to_back_slash"
+	},
+	{
 	    "caption": "Convert Case: Toggle Case",
 	    "command": "toggle_snake_camel_pascal"
 

--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -13,7 +13,8 @@
 	            { "command": "convert_to_dot", "caption": "dot.case" },
 	            { "command": "convert_to_dash", "caption": "dash-case" },
 	            { "command": "convert_to_separate_words", "caption": "separate␣words" },
-	            { "command": "convert_to_slash", "caption": "separate/with/slash" },
+                { "command": "convert_to_slash", "caption": "separate/with/slash" },
+	            { "command": "convert_to_back_slash", "caption": "separate\\with\\backslash" },
 	            { "command": "toggle_snake_camel_pascal", "caption": "Toggle Case" }
 	        ]
 	    }

--- a/case_conversion.py
+++ b/case_conversion.py
@@ -46,6 +46,10 @@ def to_slash(text, detectAcronyms, acronyms):
     words, case, sep = case_parse.parseVariable(text, detectAcronyms, acronyms, True)
     return '/'.join(words)
 
+def to_backslash(text, detectAcronyms, acronyms):
+    words, case, sep = case_parse.parseVariable(text, detectAcronyms, acronyms, True)
+    return '\\'.join(words)
+
 
 def to_separate_words(text, detectAcronyms, acronyms):
     words, case, sep = case_parse.parseVariable(text, detectAcronyms, acronyms, True)
@@ -123,3 +127,7 @@ class ConvertToSeparateWords(sublime_plugin.TextCommand):
 class ConvertToSlash(sublime_plugin.TextCommand):
     def run(self, edit):
         run_on_selections(self.view, edit, to_slash )
+
+class ConvertToBackSlash(sublime_plugin.TextCommand):
+    def run(self, edit):
+        run_on_selections(self.view, edit, to_backslash )

--- a/readme.md
+++ b/readme.md
@@ -11,7 +11,7 @@ camel, snake, dot, dash (hyphen), forward slash `/`, backslash `\` cases, and se
 - To separate words: "ctrl+alt+c", "ctrl+alt+w"
 - To separate with forward slashes: "ctrl+alt+c", "ctrl+alt+/"
 - To separate with backslashes: "ctrl+alt+c", "ctrl+alt+b"
-- To toggle between snake_case, camelCase and PascalCase: "ctrl-shift-\_"
+- To toggle between snake_case, camelCase and PascalCase: "ctrl+shift+-"
 
 ## Install
 #### Package Control

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # Case Conversion
-Case conversion is a plugin for Sublime Text 2. It converts the current word/token between pascal, 
-camel, snake, dot, dash (hyphen) cases, and separated words.
+Case Conversion is a plugin for Sublime Text. It converts the current word/token between pascal,
+camel, snake, dot, dash (hyphen), forward slash `/`, backslash `\` cases, and separated words.
 
 ## Keybindings
 - To snake_case:  "ctrl+alt+c", "ctrl+alt+s"
@@ -9,25 +9,27 @@ camel, snake, dot, dash (hyphen) cases, and separated words.
 - To dot.case: "ctrl+alt+c", "ctrl+alt+d"
 - To dash-case: "ctrl+alt+c", "ctrl+alt+h"
 - To separate words: "ctrl+alt+c", "ctrl+alt+w"
-- to separate with slashes: "ctrl+alt+c", "ctrl+alt+/"
+- To separate with forward slashes: "ctrl+alt+c", "ctrl+alt+/"
+- To separate with backslashes: "ctrl+alt+c", "ctrl+alt+b"
 - To toggle between snake_case, camelCase and PascalCase: "ctrl-shift-\_"
 
 ## Install
-#### Git Clone
-Clone this repository in to the Sublime Text 2 "Packages" directory, which is located where ever the 
-"Preferences" -> "Browse Packages" option in sublime takes you.
-
 #### Package Control
-Add https://github.com/jdc0589/CaseConversion as a Package Control repository. CaseConversion will show up in the
-package install list.
+Open the Command Palette, type ***`pci`*** to bring up **`Package Control: Install Package`**, hit Enter,
+then search for `Case Conversion`.
+
+#### Git Clone
+Clone this repository in to the Sublime Text "Packages" directory, which is located where ever the
+"Preferences" -> "Browse Packages" option in Sublime takes you.
 
 ## Contributors
 - Davis Clark
 - Scott Bessler
 - Curtis Gibby
+- Matt Morrison
 
 ## License
-Copyright (C) 2012 Davis Clark
+Copyright (C) 2012-2015 Davis Clark
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in


### PR DESCRIPTION
As a solution to [this](http://stackoverflow.com/q/32852252/1426065) Stack Overflow question, I added backslashes (`\`) to the list of separators. I also made a few minor changes to the keymap files so that everything is uniform across platforms. I updated the readme as well.