### PR TITLE
Added SCREAMING_SNAKE_CASE

### DIFF
--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -1,5 +1,6 @@
 [
   { "keys": ["ctrl+alt+c", "ctrl+alt+s"], "command": "convert_to_snake"},
+  { "keys": ["ctrl+alt+c", "ctrl+alt+shift+s"], "command": "convert_to_screaming_snake"},
   { "keys": ["ctrl+alt+c", "ctrl+alt+c"], "command": "convert_to_camel"},
   { "keys": ["ctrl+alt+c", "ctrl+alt+p"], "command": "convert_to_pascal"},
   { "keys": ["ctrl+alt+c", "ctrl+alt+d"], "command": "convert_to_dot"},

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -1,5 +1,6 @@
 [
   { "keys": ["ctrl+alt+c", "ctrl+alt+s"], "command": "convert_to_snake"},
+  { "keys": ["ctrl+alt+c", "ctrl+alt+shift+s"], "command": "convert_to_screaming_snake"},
   { "keys": ["ctrl+alt+c", "ctrl+alt+c"], "command": "convert_to_camel"},
   { "keys": ["ctrl+alt+c", "ctrl+alt+p"], "command": "convert_to_pascal"},
   { "keys": ["ctrl+alt+c", "ctrl+alt+d"], "command": "convert_to_dot"},

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -1,5 +1,6 @@
 [
   { "keys": ["ctrl+alt+c", "ctrl+alt+s"], "command": "convert_to_snake"},
+  { "keys": ["ctrl+alt+c", "ctrl+alt+shift+s"], "command": "convert_to_screaming_snake"},
   { "keys": ["ctrl+alt+c", "ctrl+alt+c"], "command": "convert_to_camel"},
   { "keys": ["ctrl+alt+c", "ctrl+alt+p"], "command": "convert_to_pascal"},
   { "keys": ["ctrl+alt+c", "ctrl+alt+d"], "command": "convert_to_dot"},

--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -12,6 +12,10 @@
 	    "command": "convert_to_snake"
 	},
 	{
+	    "caption": "Convert Case: SCREAMING_SNAKE_CASE",
+	    "command": "convert_to_screaming_snake"
+	},
+	{
 	    "caption": "Convert Case: dot.case",
 	    "command": "convert_to_dot"
 	},

--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -8,6 +8,7 @@
 	        "children":
 	        [
 	            { "command": "convert_to_snake", "caption": "snake_case" },
+	            { "command": "convert_to_screaming_snake", "caption": "SCREAMING_SNAKE_CASE" },
 	            { "command": "convert_to_camel", "caption": "camelCase" },
 	            { "command": "convert_to_pascal", "caption": "PascalCase" },
 	            { "command": "convert_to_dot", "caption": "dot.case" },

--- a/case_conversion.py
+++ b/case_conversion.py
@@ -21,6 +21,11 @@ def to_snake_case(text, detectAcronyms, acronyms):
     return '_'.join([w.lower() for w in words])
 
 
+def to_screaming_snake_case(text, detectAcronyms, acronyms):
+    words, case, sep = case_parse.parseVariable(text, detectAcronyms, acronyms)
+    return '_'.join([w.upper() for w in words])
+
+
 def to_pascal_case(text, detectAcronyms, acronyms):
     words, case, sep = case_parse.parseVariable(text, detectAcronyms, acronyms)
     return ''.join(words)
@@ -97,6 +102,11 @@ class ToggleSnakeCamelPascalCommand(sublime_plugin.TextCommand):
 class ConvertToSnakeCommand(sublime_plugin.TextCommand):
     def run(self, edit):
         run_on_selections(self.view, edit, to_snake_case)
+
+
+class ConvertToScreamingSnakeCommand(sublime_plugin.TextCommand):
+    def run(self, edit):
+        run_on_selections(self.view, edit, to_screaming_snake_case)
 
 
 class ConvertToCamel(sublime_plugin.TextCommand):

--- a/readme.md
+++ b/readme.md
@@ -1,9 +1,10 @@
 # Case Conversion
 Case Conversion is a plugin for Sublime Text. It converts the current word/token between pascal,
-camel, snake, dot, dash (hyphen), forward slash `/`, backslash `\` cases, and separated words.
+camel, snake, screaming snake, dot, dash (hyphen), forward slash `/`, backslash `\` cases, and separated words.
 
 ## Keybindings
 - To snake_case:  "ctrl+alt+c", "ctrl+alt+s"
+- To SCREAMING_SNAKE_CASE:  "ctrl+alt+c", "ctrl+alt+shift+s"
 - To camelCase: "ctrl+alt+c", "ctrl+alt+c"
 - To PascalCase: "ctrl+alt+c", "ctrl+alt+p"
 - To dot.case: "ctrl+alt+c", "ctrl+alt+d"
@@ -27,6 +28,7 @@ Clone this repository in to the Sublime Text "Packages" directory, which is loca
 - Scott Bessler
 - Curtis Gibby
 - Matt Morrison
+- Gavin Higham
 
 ## License
 Copyright (C) 2012-2015 Davis Clark


### PR DESCRIPTION
"ctrl+alt+c, ctrl+alt+s, ctrl+k, ctrl+u" was a bit too complicated,
added "ctrl+alt+c, ctrl+alt+shift+s" to convert to SCREAMING_SNAKE_CASE,
useful for defining constants in C/C++/Java etc.
