### PR TITLE
Support PHP variable prefixes

### DIFF
--- a/case_conversion.py
+++ b/case_conversion.py
@@ -17,47 +17,47 @@ SETTINGS_FILE = "CaseConversion.sublime-settings"
 
 
 def to_snake_case(text, detectAcronyms, acronyms):
-    words, case, sep = case_parse.parseVariable(text, detectAcronyms, acronyms)
-    return '_'.join([w.lower() for w in words])
+    words, case, sep, prefix = case_parse.parseVariable(text, detectAcronyms, acronyms)
+    return prefix+'_'.join([w.lower() for w in words])
 
 
 def to_pascal_case(text, detectAcronyms, acronyms):
-    words, case, sep = case_parse.parseVariable(text, detectAcronyms, acronyms)
-    return ''.join(words)
+    words, case, sep, prefix = case_parse.parseVariable(text, detectAcronyms, acronyms)
+    return prefix+''.join(words)
 
 
 def to_camel_case(text, detectAcronyms, acronyms):
-    words, case, sep = case_parse.parseVariable(text, detectAcronyms, acronyms)
+    words, case, sep, prefix = case_parse.parseVariable(text, detectAcronyms, acronyms)
     words[0] = words[0].lower()
-    return ''.join(words)
+    return prefix+''.join(words)
 
 
 def to_dot_case(text, detectAcronyms, acronyms):
-    words, case, sep = case_parse.parseVariable(text, detectAcronyms, acronyms)
+    words, case, sep, prefix = case_parse.parseVariable(text, detectAcronyms, acronyms)
     return '.'.join([w.lower() for w in words])
 
 
 def to_dash_case(text, detectAcronyms, acronyms):
-    words, case, sep = case_parse.parseVariable(text, detectAcronyms, acronyms)
+    words, case, sep, prefix = case_parse.parseVariable(text, detectAcronyms, acronyms)
     return '-'.join([w.lower() for w in words])
 
 
 def to_slash(text, detectAcronyms, acronyms):
-    words, case, sep = case_parse.parseVariable(text, detectAcronyms, acronyms, True)
+    words, case, sep, prefix = case_parse.parseVariable(text, detectAcronyms, acronyms, True)
     return '/'.join(words)
 
 def to_backslash(text, detectAcronyms, acronyms):
-    words, case, sep = case_parse.parseVariable(text, detectAcronyms, acronyms, True)
+    words, case, sep, prefix = case_parse.parseVariable(text, detectAcronyms, acronyms, True)
     return '\\'.join(words)
 
 
 def to_separate_words(text, detectAcronyms, acronyms):
-    words, case, sep = case_parse.parseVariable(text, detectAcronyms, acronyms, True)
+    words, case, sep, prefix = case_parse.parseVariable(text, detectAcronyms, acronyms, True)
     return ' '.join(words)
 
 
 def toggle_case(text, detectAcronyms, acronyms):
-    words, case, sep = case_parse.parseVariable(text, detectAcronyms, acronyms)
+    words, case, sep, prefix = case_parse.parseVariable(text, detectAcronyms, acronyms)
     if case == 'pascal' and not sep:
         return to_snake_case(text, detectAcronyms, acronyms)
     elif case == 'lower' and sep == '_':

--- a/case_parse.py
+++ b/case_parse.py
@@ -29,6 +29,12 @@ def parseVariable(var, detectAcronyms=True, acronyms=[], preserveCase=False):
     words = []
     hasSep = False
 
+    # check for starting variable identifier of $
+    variablePrefix = ''
+    if var[0:1] == "$":
+        variablePrefix = "$"
+        var = var[1:]
+
     # Index of current character. Initially 1 because we don't want to check
     # if the 0th character is a boundary.
     i = 1
@@ -239,4 +245,4 @@ def parseVariable(var, detectAcronyms=True, acronyms=[], preserveCase=False):
             else:
                 words[i] = words[i].capitalize()
 
-    return words, caseType, hasSep
+    return words, caseType, hasSep, variablePrefix


### PR DESCRIPTION
When converting between pascal, camel, and snake cases, keep the PHP variable prefix of $.
