### PR TITLE
Fix JSON parse error due to trailing comma

### DIFF
--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -52,7 +52,7 @@
                                     "default": "// Settings in here override those in \"Case Conversion/Default.sublime-settings\",\n\n{\n\t$0\n}\n"
                                 },
                                 "caption": "Key Bindings"
-                            },
+                            }
                         ]
                     }
                 ]


### PR DESCRIPTION
A recent commit added some stuff to the sublime-menu package
settings, but includes a trailing comma is causing a parse error
when the package is loaded.

This change just removes that comma.

<img width="416" alt="screen shot 2017-02-15 at 3 28 24 pm" src="https://cloud.githubusercontent.com/assets/6122/22994271/5931a91a-f394-11e6-9aba-cc02116058e8.png">
