### PR TITLE
Update toggle to include SCREAMING_SNAKE

### DIFF
--- a/case_conversion.py
+++ b/case_conversion.py
@@ -63,12 +63,14 @@ def to_separate_words(text, detectAcronyms, acronyms):
 
 def toggle_case(text, detectAcronyms, acronyms):
     words, case, sep = case_parse.parseVariable(text, detectAcronyms, acronyms)
-    if case == 'pascal' and not sep:
-        return to_snake_case(text, detectAcronyms, acronyms)
-    elif case == 'lower' and sep == '_':
+    if case == 'lower' and sep == '_':
+        return to_screaming_snake_case(text, detectAcronyms, acronyms)
+    elif case == 'upper' and sep == '_':
         return to_camel_case(text, detectAcronyms, acronyms)
     elif case == 'camel' and not sep:
         return to_pascal_case(text, detectAcronyms, acronyms)
+    elif case == 'pascal' and not sep:
+        return to_snake_case(text, detectAcronyms, acronyms)
     else:
         return text
 


### PR DESCRIPTION
This is nice for programming Ruby (or Crystal) since *the* way a Rubyist writes a constant is by letting a snake scream its name.

## acknowledgements

When I finally got to make this change I found out that Petr Marek
(mreq) already did the same thing.

https://github.com/mreq/CaseConversion/commit/64226608dd748ca43347ce0a741b2a003ccb2fe4

I updated the progression of one case into the other, it seems
logical to go from snake_case to SCREAMING_SNAKE and from
camelCase to PascalCase.